### PR TITLE
Replace empty SELECT with SELECT ISD by AID

### DIFF
--- a/src/main/scala/com/fidesmo/examples/spray/TransceiveDeliveryActor.scala
+++ b/src/main/scala/com/fidesmo/examples/spray/TransceiveDeliveryActor.scala
@@ -45,7 +45,7 @@ class TransceiveDeliveryActor(val sessionId: UUID) extends Actor with RequestBui
   val callbackHeader = addHeader("callbackUrl", callbackUrl.toString)
 
   // Post message to transceive a simple select
-  val transceive = Post(FidesmoTransceiveApi, Transceive(Seq(Hex.decodeHex("00A4040000".toCharArray)))) ~> headers ~>
+  val transceive = Post(FidesmoTransceiveApi, Transceive(Seq(Hex.decodeHex("00A4040008A00000015100000000".toCharArray)))) ~> headers ~>
     callbackHeader
 
   // Post message to signal successful service delivery


### PR DESCRIPTION
The reason is that some card configurations do not support the empty SELECT `00A4040000` so I am replacing it with a SELECT that includes the ISD's AID.
